### PR TITLE
#48 - Pseudonym darf nicht registriertem Klarnamen entsprechen

### DIFF
--- a/app_user/tests/test_forms.py
+++ b/app_user/tests/test_forms.py
@@ -31,7 +31,17 @@ class FormTests(TestCase):
 
     def test_registerAlreadyTakenNickname(self):
         data = self.form_data.copy()
+        with open('fixtures/image1.jpg', 'rb') as img:
+            data['file'] = SimpleUploadedFile(img.name, img.read())
         data['username'] = 'testuser_fix'
+        form = RegistrationForm(data=data)
+        self.assertFalse(form.is_valid())
+
+    def test_registerWithPseudonymAsRegisteredRealName(self):
+        data = self.form_data.copy()
+        with open('fixtures/image1.jpg', 'rb') as img:
+            data['file'] = SimpleUploadedFile(img.name, img.read())
+        data['username'] = 'Bernd Lullert'
         form = RegistrationForm(data=data)
         self.assertFalse(form.is_valid())
 

--- a/app_user/views.py
+++ b/app_user/views.py
@@ -114,8 +114,6 @@ def register_user(request):
 
 class UserUpdate(FormMessagesMixin, UpdateView):
     model = User
-    model._meta.get_field('username').error_messages = {'unique': 'Das gewählte Pseudonym ist bereits vergeben.',
-                                                        'invalid': 'Bitte ein gültiges Pseudonym eingeben. Dieses darf nur Buchstaben, Ziffern und @/./+/-/_ enthalten.'}
     form_class = CustomUpdateForm
     form_invalid_message = _('Account konnte nicht aktualisiert werden.')
     form_valid_message = _('Account wurde erfolgreich aktualisiert.')


### PR DESCRIPTION
Habe einen eigenen Validator für das username-Feld und einen Testfall hinzugefügt.