### PR TITLE
B59: Mailversand für Benachrichtigungen

### DIFF
--- a/app_notification/templates/notifications.html
+++ b/app_notification/templates/notifications.html
@@ -7,7 +7,13 @@
         <h4>
             Ihre Nachrichten
         </h4>
-
+        <div class="switch text-right" style="margin-bottom: 20px;">
+            <label>
+                Email-Benachrichtigung
+                <input id="notification-toggle" {% if user.enabled_notifications_via_email %} checked {% endif %}type="checkbox">
+                <span class="lever"></span>
+            </label>
+        </div>
         <div id="accordion">
             {% if notifications.count > 0 %}
                 <ul class="notifications collapsible" data-collapsible="accordion">
@@ -100,6 +106,13 @@
         $(document).ready(function () {
             $('.collapsible').collapsible({
                 accordion: true // A setting that changes the collapsible behavior to expandable instead of the default accordion style
+            });
+
+            $('#notification-toggle').change(function() {
+                $.ajax({
+                    method: 'post',
+                    url: '/notifications/toggleEmail/'
+                });
             });
 
             $('ul.notifications li.new').on('click', function(event) {

--- a/app_notification/urls.py
+++ b/app_notification/urls.py
@@ -5,6 +5,7 @@ from . import views
 
 urlpatterns = [
     url(r'^notifications/(?P<id>[0-9]+)/read/', views.read_notification, name='read-notification'),
+    url(r'^notifications/toggleEmail/', views.notificationEmailToggle, name='notificationEmailToggle'),
     url(r'^notifications/', views.notificationPageView, name='notificationsPage'),
     url(r'^notificationSendBook/(?P<id>[0-9]+)', views.notificationSendBookPageView, name='notificationsSendBookPage'),
 ]

--- a/app_user/models.py
+++ b/app_user/models.py
@@ -67,6 +67,7 @@ class User(AuthUser):
     location = models.CharField(('Ort'),max_length=255, default='')
     paypal = models.CharField(max_length=50)
     user_ptr = models.OneToOneField(AuthUser)
+    enabled_notifications_via_email = models.BooleanField(default=True)
     showcaseDisabled = models.BooleanField(default=False, verbose_name='Schaufenster gesperrt')
 
     objects = MyUserManager()


### PR DESCRIPTION
Der Einfachkeit halber habe ich die URL hartkodiert, da im Gegensatz zum Mailversand bei der Registrierung kein Request vorhanden ist, aus welchem ich den Host ziehen könnte.

Auf die schnelle ist mir keine Möglichkeit eingefallen, für meinen Zusatz einen Test zu schreiben. Händisch hat das ganze funktioniert. :3